### PR TITLE
Mark the pages as UTF-8

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Are we e10s yet?</title>
     <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, target-densitydpi=device-dpi">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">

--- a/template.html
+++ b/template.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Are we e10s yet?</title>
     <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height, target-densitydpi=device-dpi">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">


### PR DESCRIPTION
Non-ASCII characters are garbled
e.g. `feca4b87-3be4-43da-a1b1-137c24220968@jetpack` on the page.
as well as fanqianbao@fqb, mtkan@mtkan.net, huimai@favormy.com, and more.

`The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.` on Web Console.